### PR TITLE
Make ELFFile constructor public

### DIFF
--- a/Sources/ELFKit/ELFFile.swift
+++ b/Sources/ELFKit/ELFFile.swift
@@ -25,7 +25,7 @@ public class ELFFile {
     /// ELF header
     public let header: ELFHeader
 
-    init(url: URL) throws {
+    public init(url: URL) throws {
         self.url = url
         self.fileHandle = try FileHandle(forReadingFrom: url)
 


### PR DESCRIPTION
This is needed to be able to use the API from external modules.