### PR TITLE
Conditionally define dl_phdr_info only if __musl__ unset

### DIFF
--- a/Sources/ELFKitC/include/elf_linux.h
+++ b/Sources/ELFKitC/include/elf_linux.h
@@ -13,7 +13,9 @@
 
 #include <link.h>
 
-#if 0
+// need to check for __musl__ or else:
+// ELFKit/Sources/ELFKitC/include/elf_linux.h:17:8: error: redefinition of 'dl_phdr_info'
+#ifndef __musl__
 struct dl_phdr_info {
     ElfW(Addr)        dlpi_addr;
     const char       *dlpi_name;

--- a/Sources/ELFKitC/include/elf_linux.h
+++ b/Sources/ELFKitC/include/elf_linux.h
@@ -13,12 +13,14 @@
 
 #include <link.h>
 
+#if 0
 struct dl_phdr_info {
     ElfW(Addr)        dlpi_addr;
     const char       *dlpi_name;
     const ElfW(Phdr) *dlpi_phdr;
     ElfW(Half)        dlpi_phnum;
 };
+#endif
 
 extern int dl_iterate_phdr(int (*callback) (struct dl_phdr_info *info, size_t size, void *data), void *data);
 


### PR DESCRIPTION
Building with the [static Linux SDK](https://www.swift.org/install/macos/#other-install-options) raises errors:

```
$ ~/Library/Developer/Toolchains/swift-6.1-RELEASE.xctoolchain/usr/bin/swift build --swift-sdk x86_64-swift-linux-musl

Building for debugging...
<module-includes>:5:10: note: in file included from <module-includes>:5:
3 | #include "/opt/src/github/marcprux/ELFKit/Sources/ELFKitC/include/elf64.h"
4 | #include "/opt/src/github/marcprux/ELFKit/Sources/ELFKitC/include/elf_common.h"
5 | #include "/opt/src/github/marcprux/ELFKit/Sources/ELFKitC/include/elf_linux.h"
  |          `- note: in file included from <module-includes>:5:
6 | 

/opt/src/github/marcprux/ELFKit/Sources/ELFKitC/include/elf_linux.h:17:8: error: redefinition of 'dl_phdr_info'
15 | 
16 | //#ifndef __musl__
17 | struct dl_phdr_info {
   |        `- error: redefinition of 'dl_phdr_info'
18 |     ElfW(Addr)        dlpi_addr;
19 |     const char       *dlpi_name;

/Users/marc/Library/org.swift.swiftpm/swift-sdks/swift-6.1-RELEASE_static-linux-0.0.1.artifactbundle/swift-6.1-RELEASE_static-linux-0.0.1/swift-linux-musl/musl-1.2.5.sdk/x86_64/usr/include/link.h:20:8: note: previous definition is here
18 | #include <bits/link.h>
19 | 
20 | struct dl_phdr_info {
   |        `- note: previous definition is here
21 | 	ElfW(Addr) dlpi_addr;
22 | 	const char *dlpi_name;
```

Conditionally defining `dl_phdr_info` only when `#ifndef __musl__` seems to resolve the issue.