### PR TITLE
Add support for obtaining PLT relocations via dynamics

### DIFF
--- a/Sources/ELFKit/Extension/ELFDynamic+.swift
+++ b/Sources/ELFKit/Extension/ELFDynamic+.swift
@@ -31,6 +31,9 @@ extension Sequence where Element: ELFDynamicProtocol {
     var _relsz: Element? { first(where: { $0._commonTag == .relsz }) }
     var _relcount: Element? { first(where: { $0._commonTag == .relcount }) }
     var _relent: Element? { first(where: { $0._commonTag == .relent }) }
+    var _jmprel: Element? { first(where: { $0._commonTag == .jmprel }) }
+    var _pltrel: Element? { first(where: { $0._commonTag == .pltrel }) }
+    var _pltrelsz: Element? { first(where: { $0._commonTag == .pltrelsz }) }
 
     var _rpath: [Element] { filter { $0._commonTag == .rpath } }
     var _runpath: [Element] { filter { $0._commonTag == .runpath } }

--- a/Sources/ELFKit/Extension/ELFFile+Dynamics64+.swift
+++ b/Sources/ELFKit/Extension/ELFFile+Dynamics64+.swift
@@ -39,6 +39,49 @@ extension ELFFile.Dynamics64 {
         }
         return nil
     }
+
+    public func pltRelocations(in elf: ELFFile) -> AnyRandomAccessCollection<ELF64Relocation>? {
+        guard let _jmprel, let _pltrelsz, let _pltrel else {
+            return nil
+        }
+        guard let offset = elf.fileOffset(of: _jmprel.pointer) else {
+            return nil
+        }
+        guard let pltrelType = DynamicTag(
+            rawValue: numericCast(_pltrel.value),
+            osabi: .none,
+            machine: .none
+        ) else {
+            return nil
+        }
+
+        switch pltrelType {
+        case .rel:
+            let entrySize = _relent?.value ?? ELF64RelocationInfo.layoutSize
+            guard entrySize > 0 else { return nil }
+            let sequence: DataSequence<ELF64RelocationInfo> = elf.fileHandle.readDataSequence(
+                offset: numericCast(offset),
+                numberOfElements: _pltrelsz.value / entrySize
+            )
+            return AnyRandomAccessCollection(
+                sequence.map { .general($0) }
+            )
+
+        case .rela:
+            let entrySize = _relaent?.value ?? ELF64RelocationAddendInfo.layoutSize
+            guard entrySize > 0 else { return nil }
+            let sequence: DataSequence<ELF64RelocationAddendInfo> = elf.fileHandle.readDataSequence(
+                offset: numericCast(offset),
+                numberOfElements: _pltrelsz.value / entrySize
+            )
+            return AnyRandomAccessCollection(
+                sequence.map { .addend($0) }
+            )
+
+        default:
+            return nil
+        }
+    }
 }
 
 // MARK: - Version Defs

--- a/Sources/ELFKit/Protocol/ELFDynamicsSequence.swift
+++ b/Sources/ELFKit/Protocol/ELFDynamicsSequence.swift
@@ -102,6 +102,7 @@ where Element == Dynamic,
     func symbolInfos(in elf: ELF) -> SymbolInfos?
 
     func relocations(in elf: ELF) -> AnyRandomAccessCollection<Dynamic.Relocation>?
+    func pltRelocations(in elf: ELF) -> AnyRandomAccessCollection<Dynamic.Relocation>?
 
     var flags: DynamicFlags { get }
     var flags1: DynamicFlags1 { get }

--- a/Sources/ELFKit/Protocol/ELFFileDynamicsSequence.swift
+++ b/Sources/ELFKit/Protocol/ELFFileDynamicsSequence.swift
@@ -34,6 +34,7 @@ where Iterator == WrappedSequence.Iterator {
     func symbolInfos(in elf: ELFFile) -> DataSequence<Dynamic.SymbolInfo>?
 
     func relocations(in elf: ELFFile) -> AnyRandomAccessCollection<Dynamic.Relocation>?
+    func pltRelocations(in elf: ELFFile) -> AnyRandomAccessCollection<Dynamic.Relocation>?
 
     var flags: DynamicFlags { get }
     var flags1: DynamicFlags1 { get }

--- a/Sources/ELFKit/Protocol/ELFImageDynamicsSequence.swift
+++ b/Sources/ELFKit/Protocol/ELFImageDynamicsSequence.swift
@@ -34,6 +34,7 @@ where Iterator == WrappedSequence.Iterator {
     func symbolInfos(in elf: ELFImage) -> MemorySequence<Dynamic.SymbolInfo>?
 
     func relocations(in elf: ELFImage) -> AnyRandomAccessCollection<Dynamic.Relocation>?
+    func pltRelocations(in elf: ELFImage) -> AnyRandomAccessCollection<Dynamic.Relocation>?
 
     var flags: DynamicFlags { get }
     var flags1: DynamicFlags1 { get }


### PR DESCRIPTION
- Introduced `pltRelocations` method for both 32-bit and 64-bit ELF files
- Added `pltRelocations` method to ELFDynamicsSequence protocol
- Updated ELFImageDynamicsSequence and ELFFileDynamicsSequence protocols