### PR TITLE
Add DT_RELR / SHT_RELR support with raw entry and expanded relocation

### DIFF
--- a/Sources/ELFKit/Extension/ELFDynamic+.swift
+++ b/Sources/ELFKit/Extension/ELFDynamic+.swift
@@ -31,6 +31,9 @@ extension Sequence where Element: ELFDynamicProtocol {
     var _relsz: Element? { first(where: { $0._commonTag == .relsz }) }
     var _relcount: Element? { first(where: { $0._commonTag == .relcount }) }
     var _relent: Element? { first(where: { $0._commonTag == .relent }) }
+    var _relr: Element? { first(where: { $0._commonTag == .relr }) }
+    var _relrsz: Element? { first(where: { $0._commonTag == .relrsz }) }
+    var _relrent: Element? { first(where: { $0._commonTag == .relrent }) }
     var _jmprel: Element? { first(where: { $0._commonTag == .jmprel }) }
     var _pltrel: Element? { first(where: { $0._commonTag == .pltrel }) }
     var _pltrelsz: Element? { first(where: { $0._commonTag == .pltrelsz }) }

--- a/Sources/ELFKit/Model/Relocation/ELFRelrEntry.swift
+++ b/Sources/ELFKit/Model/Relocation/ELFRelrEntry.swift
@@ -1,0 +1,22 @@
+//
+//  ELFRelrEntry.swift
+//  ELFKit
+//
+//  Created by Codex on 2026/03/02.
+//
+//
+
+import Foundation
+
+/// Raw packed RELR entry decoded from `DT_RELR` / `SHT_RELR`.
+public enum ELFRelrEntry: Sendable, Hashable {
+    case address(UInt64)
+    case bitmap(UInt64)
+
+    public var rawValue: UInt64 {
+        switch self {
+        case let .address(value), let .bitmap(value):
+            value
+        }
+    }
+}

--- a/Sources/ELFKit/Model/Relocation/ELFRelrRelocation.swift
+++ b/Sources/ELFKit/Model/Relocation/ELFRelrRelocation.swift
@@ -1,0 +1,77 @@
+//
+//  ELFRelrRelocation.swift
+//  ELFKit
+//
+//  Created by Codex on 2026/03/02.
+//
+//
+
+import Foundation
+
+/// Expanded relative relocation entry decoded from `DT_RELR` / `SHT_RELR`.
+public struct ELFRelrRelocation: Sendable, Hashable {
+    public let offset: Int
+
+    public init(offset: Int) {
+        self.offset = offset
+    }
+}
+
+extension ELFRelrRelocation {
+    /// Reads the implicit addend stored at the relocation target in the file image.
+    public func addend(in elf: ELFFile) -> Int? {
+        elf._readPointerValue(atVirtualAddress: offset)
+    }
+}
+
+extension ELFRelrRelocation {
+    /// Reads the currently stored pointer value at the relocation target in memory.
+    public func currentValue(in elf: ELFImage) -> Int? {
+        elf._readPointerValue(atRelativeOffset: offset)
+    }
+
+    /// Derives the implicit addend by subtracting the loaded image base.
+    public func addend(in elf: ELFImage) -> Int? {
+        guard let currentValue = currentValue(in: elf) else { return nil }
+        return currentValue &- Int(bitPattern: elf.ptr)
+    }
+}
+
+extension ELFFile {
+    fileprivate func _readPointerValue(atVirtualAddress virtualAddress: Int) -> Int? {
+        guard virtualAddress >= 0 else { return nil }
+        guard let offset = fileOffset(of: virtualAddress) else {
+            return nil
+        }
+
+        if is64Bit {
+            guard let value: UInt64 = try? fileHandle.read(offset: offset) else {
+                return nil
+            }
+            return numericCast(value)
+        } else {
+            guard let value: UInt32 = try? fileHandle.read(offset: offset) else {
+                return nil
+            }
+            return numericCast(value)
+        }
+    }
+}
+
+extension ELFImage {
+    fileprivate func _readPointerValue(atRelativeOffset relativeOffset: Int) -> Int? {
+        guard relativeOffset >= 0 else { return nil }
+
+        if is64Bit {
+            let pointer = ptr
+                .advanced(by: relativeOffset)
+                .assumingMemoryBound(to: UInt64.self)
+            return numericCast(pointer.pointee)
+        } else {
+            let pointer = ptr
+                .advanced(by: relativeOffset)
+                .assumingMemoryBound(to: UInt32.self)
+            return numericCast(pointer.pointee)
+        }
+    }
+}

--- a/Sources/ELFKit/Protocol/ELFDynamicsSequence.swift
+++ b/Sources/ELFKit/Protocol/ELFDynamicsSequence.swift
@@ -101,7 +101,11 @@ where Element == Dynamic,
 
     func symbolInfos(in elf: ELF) -> SymbolInfos?
 
+    /// Raw packed RELR entries retrieved from `DT_RELR`.
+    func relrEntries(in elf: ELF) -> [ELFRelrEntry]?
     func relocations(in elf: ELF) -> AnyRandomAccessCollection<Dynamic.Relocation>?
+    /// Expanded relative relocations decoded from `DT_RELR`.
+    func relrRelocations(in elf: ELF) -> [ELFRelrRelocation]?
     func pltRelocations(in elf: ELF) -> AnyRandomAccessCollection<Dynamic.Relocation>?
 
     var flags: DynamicFlags { get }

--- a/Sources/ELFKit/Protocol/ELFFileDynamicsSequence.swift
+++ b/Sources/ELFKit/Protocol/ELFFileDynamicsSequence.swift
@@ -33,7 +33,9 @@ where Iterator == WrappedSequence.Iterator {
 
     func symbolInfos(in elf: ELFFile) -> DataSequence<Dynamic.SymbolInfo>?
 
+    func relrEntries(in elf: ELFFile) -> [ELFRelrEntry]?
     func relocations(in elf: ELFFile) -> AnyRandomAccessCollection<Dynamic.Relocation>?
+    func relrRelocations(in elf: ELFFile) -> [ELFRelrRelocation]?
     func pltRelocations(in elf: ELFFile) -> AnyRandomAccessCollection<Dynamic.Relocation>?
 
     var flags: DynamicFlags { get }
@@ -294,6 +296,60 @@ extension ELFFileDynamicsSequence where Dynamic.Relocation: ELFRelocationLayoutC
         default:
             return nil
         }
+    }
+}
+
+extension ELFFileDynamicsSequence where Dynamic == ELF32Dynamic {
+    public func relrEntries(in elf: ELFFile) -> [ELFRelrEntry]? {
+        guard let _relr, let _relrsz else { return nil }
+
+        let entrySize = _relrent?.value ?? MemoryLayout<UInt32>.size
+        guard entrySize == MemoryLayout<UInt32>.size else { return nil }
+        guard _relrsz.value % entrySize == 0 else { return nil }
+        guard let offset = elf.fileOffset(of: _relr.pointer) else {
+            return nil
+        }
+
+        let sequence: DataSequence<UInt32> = elf.fileHandle.readDataSequence(
+            offset: numericCast(offset),
+            numberOfElements: _relrsz.value / entrySize
+        )
+        return _ELFRelrRelocationDecoder.entries(sequence)
+    }
+
+    public func relrRelocations(in elf: ELFFile) -> [ELFRelrRelocation]? {
+        guard let entries = relrEntries(in: elf) else { return nil }
+        return _ELFRelrRelocationDecoder.decode(
+            entries,
+            wordSize: MemoryLayout<UInt32>.size
+        )
+    }
+}
+
+extension ELFFileDynamicsSequence where Dynamic == ELF64Dynamic {
+    public func relrEntries(in elf: ELFFile) -> [ELFRelrEntry]? {
+        guard let _relr, let _relrsz else { return nil }
+
+        let entrySize = _relrent?.value ?? MemoryLayout<UInt64>.size
+        guard entrySize == MemoryLayout<UInt64>.size else { return nil }
+        guard _relrsz.value % entrySize == 0 else { return nil }
+        guard let offset = elf.fileOffset(of: _relr.pointer) else {
+            return nil
+        }
+
+        let sequence: DataSequence<UInt64> = elf.fileHandle.readDataSequence(
+            offset: numericCast(offset),
+            numberOfElements: _relrsz.value / entrySize
+        )
+        return _ELFRelrRelocationDecoder.entries(sequence)
+    }
+
+    public func relrRelocations(in elf: ELFFile) -> [ELFRelrRelocation]? {
+        guard let entries = relrEntries(in: elf) else { return nil }
+        return _ELFRelrRelocationDecoder.decode(
+            entries,
+            wordSize: MemoryLayout<UInt64>.size
+        )
     }
 }
 

--- a/Sources/ELFKit/Protocol/ELFImageDynamicsSequence.swift
+++ b/Sources/ELFKit/Protocol/ELFImageDynamicsSequence.swift
@@ -33,7 +33,9 @@ where Iterator == WrappedSequence.Iterator {
 
     func symbolInfos(in elf: ELFImage) -> MemorySequence<Dynamic.SymbolInfo>?
 
+    func relrEntries(in elf: ELFImage) -> [ELFRelrEntry]?
     func relocations(in elf: ELFImage) -> AnyRandomAccessCollection<Dynamic.Relocation>?
+    func relrRelocations(in elf: ELFImage) -> [ELFRelrRelocation]?
     func pltRelocations(in elf: ELFImage) -> AnyRandomAccessCollection<Dynamic.Relocation>?
 
     var flags: DynamicFlags { get }
@@ -300,6 +302,60 @@ extension ELFImageDynamicsSequence where Dynamic.Relocation: ELFRelocationLayout
         default:
             return nil
         }
+    }
+}
+
+extension ELFImageDynamicsSequence where Dynamic == ELF32Dynamic {
+    public func relrEntries(in elf: ELFImage) -> [ELFRelrEntry]? {
+        guard let _relr, let _relrsz else { return nil }
+
+        let entrySize = _relrent?.value ?? MemoryLayout<UInt32>.size
+        guard entrySize == MemoryLayout<UInt32>.size else { return nil }
+        guard _relrsz.value % entrySize == 0 else { return nil }
+        guard let pointer = _relr.pointer(for: elf) else {
+            return nil
+        }
+
+        let sequence: MemorySequence<UInt32> = .init(
+            basePointer: pointer.assumingMemoryBound(to: UInt32.self),
+            numberOfElements: _relrsz.value / entrySize
+        )
+        return _ELFRelrRelocationDecoder.entries(sequence)
+    }
+
+    public func relrRelocations(in elf: ELFImage) -> [ELFRelrRelocation]? {
+        guard let entries = relrEntries(in: elf) else { return nil }
+        return _ELFRelrRelocationDecoder.decode(
+            entries,
+            wordSize: MemoryLayout<UInt32>.size
+        )
+    }
+}
+
+extension ELFImageDynamicsSequence where Dynamic == ELF64Dynamic {
+    public func relrEntries(in elf: ELFImage) -> [ELFRelrEntry]? {
+        guard let _relr, let _relrsz else { return nil }
+
+        let entrySize = _relrent?.value ?? MemoryLayout<UInt64>.size
+        guard entrySize == MemoryLayout<UInt64>.size else { return nil }
+        guard _relrsz.value % entrySize == 0 else { return nil }
+        guard let pointer = _relr.pointer(for: elf) else {
+            return nil
+        }
+
+        let sequence: MemorySequence<UInt64> = .init(
+            basePointer: pointer.assumingMemoryBound(to: UInt64.self),
+            numberOfElements: _relrsz.value / entrySize
+        )
+        return _ELFRelrRelocationDecoder.entries(sequence)
+    }
+
+    public func relrRelocations(in elf: ELFImage) -> [ELFRelrRelocation]? {
+        guard let entries = relrEntries(in: elf) else { return nil }
+        return _ELFRelrRelocationDecoder.decode(
+            entries,
+            wordSize: MemoryLayout<UInt64>.size
+        )
     }
 }
 

--- a/Sources/ELFKit/Protocol/ELFSectionHeaderProtocol.swift
+++ b/Sources/ELFKit/Protocol/ELFSectionHeaderProtocol.swift
@@ -31,8 +31,13 @@ public protocol ELFSectionHeaderProtocol: Sendable {
     func name(in elf: ELFFile) -> String?
 
     func _strings(in elf: ELFFile) -> ELFFile.Strings?
+
     func _relocations(in elf: ELFFile) -> AnyRandomAccessCollection<Relocation>?
+    func _relrEntries(in elf: ELFFile) -> [ELFRelrEntry]?
+    func _relrRelocations(in elf: ELFFile) -> [ELFRelrRelocation]?
+
     func _notes(in elf: ELFFile) -> _ELFNotes<Note>?
+
     func _dynamics(in elf: ELFFile) -> DataSequence<Dynamic>?
 
     func _hashTableHeader(in elf: ELFFile) -> Dynamic.HashTableHeader?
@@ -147,6 +152,41 @@ extension ELFSectionHeaderProtocol where Relocation: ELFRelocationLayoutConverti
         default:
             return nil
         }
+    }
+}
+
+extension ELFSectionHeaderProtocol {
+    public func _relrEntries(in elf: ELFFile) -> [ELFRelrEntry]? {
+        guard type(inELF: elf.header) == .relr else { return nil }
+
+        let wordSize = elf.is64Bit ? MemoryLayout<UInt64>.size : MemoryLayout<UInt32>.size
+        let relrEntrySize = entrySize > 0 ? entrySize : wordSize
+
+        guard relrEntrySize == wordSize else { return nil }
+        guard size % relrEntrySize == 0 else { return nil }
+
+        if elf.is64Bit {
+            let sequence: DataSequence<UInt64> = elf.fileHandle.readDataSequence(
+                offset: numericCast(offset),
+                numberOfElements: size / relrEntrySize
+            )
+            return _ELFRelrRelocationDecoder.entries(sequence)
+        }
+
+        let sequence: DataSequence<UInt32> = elf.fileHandle.readDataSequence(
+            offset: numericCast(offset),
+            numberOfElements: size / relrEntrySize
+        )
+        return _ELFRelrRelocationDecoder.entries(sequence)
+    }
+
+    public func _relrRelocations(in elf: ELFFile) -> [ELFRelrRelocation]? {
+        guard let entries = _relrEntries(in: elf) else { return nil }
+        let wordSize = elf.is64Bit ? MemoryLayout<UInt64>.size : MemoryLayout<UInt32>.size
+        return _ELFRelrRelocationDecoder.decode(
+            entries,
+            wordSize: wordSize
+        )
     }
 }
 

--- a/Sources/ELFKit/Util/RelrRelocationDecoder.swift
+++ b/Sources/ELFKit/Util/RelrRelocationDecoder.swift
@@ -1,0 +1,64 @@
+//
+//  RelrRelocationDecoder.swift
+//  ELFKit
+//
+//  Created by Codex on 2026/03/02.
+//
+//
+
+import Foundation
+
+enum _ELFRelrRelocationDecoder {
+    static func entries<Entry>(
+        _ values: some Sequence<Entry>
+    ) -> [ELFRelrEntry] where Entry: FixedWidthInteger {
+        values.map { value in
+            let rawValue: UInt64 = numericCast(value)
+            if value & 1 == 0 {
+                return .address(rawValue)
+            }
+            return .bitmap(rawValue)
+        }
+    }
+
+    static func decode<Entry>(
+        _ values: some Sequence<Entry>
+    ) -> [ELFRelrRelocation] where Entry: FixedWidthInteger {
+        decode(
+            entries(values),
+            wordSize: MemoryLayout<Entry>.size
+        )
+    }
+
+    static func decode(
+        _ entries: some Sequence<ELFRelrEntry>,
+        wordSize: Int
+    ) -> [ELFRelrRelocation] {
+        let bitmapBitCount = (wordSize * 8) - 1
+
+        var nextOffset = 0
+        var relocations: [ELFRelrRelocation] = []
+
+        for entry in entries {
+            switch entry {
+            case let .address(rawOffset):
+                let offset: Int = numericCast(rawOffset)
+                relocations.append(.init(offset: offset))
+                nextOffset = offset + wordSize
+
+            case let .bitmap(rawValue):
+                let bitmap = rawValue >> 1
+                for bitIndex in 0..<bitmapBitCount {
+                    let mask = UInt64(1) << bitIndex
+                    guard bitmap & mask != 0 else { continue }
+                    relocations.append(
+                        .init(offset: nextOffset + (bitIndex * wordSize))
+                    )
+                }
+                nextOffset += bitmapBitCount * wordSize
+            }
+        }
+
+        return relocations
+    }
+}

--- a/Tests/ELFKitTests/ELFFilePrintTests.swift
+++ b/Tests/ELFKitTests/ELFFilePrintTests.swift
@@ -196,6 +196,30 @@ extension ELFFilePrintTests {
         )
     }
 
+    func testRelrRelocations() {
+        let relocations: [ELFRelrRelocation]?
+        if let dynamics = elf.dynamics64 {
+            relocations = dynamics.relrRelocations(in: elf)
+        } else if let dynamics = elf.dynamics32 {
+            relocations = dynamics.relrRelocations(in: elf)
+        } else {
+            relocations = nil
+        }
+
+        guard let relocations else { return }
+
+        print("DT_RELR:")
+        for (i, relocation) in relocations.enumerated() {
+            print(" ----")
+            print(" [\(i)]")
+            print(" Offset:", String(relocation.offset, radix: 16))
+            print(
+                " Addend:",
+                String(relocation.addend(in: elf) ?? 0, radix: 16)
+            )
+        }
+    }
+
     func testVersionDef() {
         guard let dynamics = elf.dynamics64 else { return }
         let versionDefs = dynamics.versionDefs(in: elf)


### PR DESCRIPTION
## Summary
This PR adds support for packed relative relocations in ELF binaries.

ELFKit already defined the DT_RELR tags, but did not expose decoding logic. This change adds APIs for both:

- reading raw packed RELR entries
- expanding them into relocation offsets
- reading implicit addends and resolved values from file/image targets
- accessing RELR data from both dynamic tags and SHT_RELR sections